### PR TITLE
182465391 - remove rest client

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Set up OmniFixture client
 @omni_fixture.all(omni_parser_id)
 ```
 
+## Testing
+Install all required gems (which are listed in .gemspec file) and run `rake test` in order to run tests.
+
 ## Contributing
 Contact: http://www.firstmoversadvantage.com
 

--- a/lib/omni_parse_client_ruby/connection.rb
+++ b/lib/omni_parse_client_ruby/connection.rb
@@ -33,7 +33,8 @@ module OmniparseClient
       Net::HTTPGatewayTimeout,
       Net::HTTPInsufficientStorage,
       Net::HTTPLoopDetected,
-      Net::HTTPRequestTimeout
+      Net::HTTPRequestTimeout,
+      Net::HTTPBadRequest
     ].freeze
 
     # constructor
@@ -113,6 +114,8 @@ module OmniparseClient
         sleep(RETRIES_DELAYS_ARRAY[@retry_index])
         @retry_index += 1
         retry
+      rescue Net::HTTPClientException => e
+        raise Net::HTTPClientException.new(e.message.tr('"', ''), e.response)
       end
     end
 

--- a/lib/omni_parse_client_ruby/connection.rb
+++ b/lib/omni_parse_client_ruby/connection.rb
@@ -48,12 +48,15 @@ module OmniparseClient
     def omni_get(request_url, params = {}, headers = {})
       uri = URI(request_url)
       uri.query = URI.encode_www_form(params)
+      req = Net::HTTP::Get.new(uri)
       headers.each do |header, val|
-        uri[header] = val
+        req[header] = val
       end
 
       retry_on_server_error do
-        res = Net::HTTP.get_response(uri)
+        res = Net::HTTP.start(uri.hostname, uri.port) do |http|
+          http.request(req)
+        end
         res.error! if !res.is_a?(Net::HTTPSuccess) && CLIENT_ERRORS.include?(res.code_type)
 
         res
@@ -62,12 +65,16 @@ module OmniparseClient
 
     def omni_post(request_url, params = {}, headers = {})
       uri = URI(request_url)
+      req = Net::HTTP::Post.new(uri)
+      req.set_form_data(params)
       headers.each do |header, val|
-        uri[header] = val
+        req[header] = val
       end
 
       retry_on_server_error do
-        res = Net::HTTP.post_form(uri, params)
+        res = Net::HTTP.start(uri.hostname, uri.port) do |http|
+          http.request(req)
+        end
         res.error! if !res.is_a?(Net::HTTPSuccess) && CLIENT_ERRORS.include?(res.code_type)
 
         res

--- a/lib/omni_parse_client_ruby/connection.rb
+++ b/lib/omni_parse_client_ruby/connection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rest-client'
+require 'net/http'
 
 module OmniparseClient
   # Connection module
@@ -18,16 +18,23 @@ module OmniparseClient
     RETRIES_DELAYS_ARRAY  =
       ENV['OMNI_RETRIES_DELAYS_ARRAY']&.split(',')&.map(&:to_i) ||
       [5, 30, 2 * 60, 10 * 60, 30 * 60].freeze
-    RETRY_ON_ERRORS = [
-      RestClient::InternalServerError,
-      RestClient::NotImplemented,
-      RestClient::BadGateway,
-      RestClient::ServiceUnavailable,
-      RestClient::GatewayTimeout,
-      RestClient::InsufficientStorage,
-      RestClient::LoopDetected,
+    EXCEPTIONS_INCLUDING_MESSAGES = [
       SocketError,
-      RestClient::Exceptions::OpenTimeout
+      Net::OpenTimeout
+    ].freeze
+    EXCEPTIONS_EXCLUDING_MESSAGES = [
+      Net::HTTPFatalError
+    ].freeze
+    CLIENT_ERRORS = [
+      Net::HTTPInternalServerError,
+      Net::HTTPNotImplemented,
+      Net::HTTPBadGateway,
+      Net::HTTPServiceUnavailable,
+      Net::HTTPGatewayTimeout,
+      Net::HTTPInsufficientStorage,
+      Net::HTTPLoopDetected,
+      Net::HTTPGatewayTimeout,
+      Net::HTTPRequestTimeout
     ].freeze
 
     # constructor
@@ -38,12 +45,33 @@ module OmniparseClient
       @api_key    = p[:api_key]
     end
 
-    def omni_get(request_url, params = {})
-      retry_on_server_error { RestClient.get(request_url, params) }
+    def omni_get(request_url, params = {}, headers = {})
+      uri = URI(request_url)
+      uri.query = URI.encode_www_form(params)
+      headers.each do |header, val|
+        uri[header] = val
+      end
+
+      retry_on_server_error do
+        res = Net::HTTP.get_response(uri)
+        res.error! if !res.is_a?(Net::HTTPSuccess) && CLIENT_ERRORS.include?(res.code_type)
+
+        res
+      end
     end
 
-    def omni_post(request, params = {}, headers = {})
-      retry_on_server_error { RestClient.post(request, params, headers) }
+    def omni_post(request_url, params = {}, headers = {})
+      uri = URI(request_url)
+      headers.each do |header, val|
+        uri[header] = val
+      end
+
+      retry_on_server_error do
+        res = Net::HTTP.post_form(uri, params)
+        res.error! if !res.is_a?(Net::HTTPSuccess) && CLIENT_ERRORS.include?(res.code_type)
+
+        res
+      end
     end
 
     # headers
@@ -61,7 +89,7 @@ module OmniparseClient
     # TEST connection
     def test_connection
       request_url = base_url + test_connection_path
-      response = omni_get(request_url, headers)
+      response = omni_get(request_url, {}, headers)
       response
     end
 
@@ -76,8 +104,15 @@ module OmniparseClient
       @retry_index = 0
       begin
         yield block
-      rescue *RETRY_ON_ERRORS => e
+      rescue *EXCEPTIONS_INCLUDING_MESSAGES => e
         raise RetriesLimitReached, e.message if retries_limit_reached?
+
+        sleep(RETRIES_DELAYS_ARRAY[@retry_index])
+        @retry_index += 1
+        retry
+      rescue *EXCEPTIONS_EXCLUDING_MESSAGES => e
+        message = "#{e&.data&.code} #{e&.data&.code_type}"
+        raise RetriesLimitReached, message if retries_limit_reached?
 
         sleep(RETRIES_DELAYS_ARRAY[@retry_index])
         @retry_index += 1

--- a/lib/omni_parse_client_ruby/connection.rb
+++ b/lib/omni_parse_client_ruby/connection.rb
@@ -33,7 +33,6 @@ module OmniparseClient
       Net::HTTPGatewayTimeout,
       Net::HTTPInsufficientStorage,
       Net::HTTPLoopDetected,
-      Net::HTTPGatewayTimeout,
       Net::HTTPRequestTimeout
     ].freeze
 
@@ -118,8 +117,10 @@ module OmniparseClient
         @retry_index += 1
         retry
       rescue *EXCEPTIONS_EXCLUDING_MESSAGES => e
-        message = "#{e&.data&.code} #{e&.data&.code_type}"
-        raise RetriesLimitReached, message if retries_limit_reached?
+        if retries_limit_reached?
+          message = "#{e&.data&.code} #{e&.data&.code_type}"
+          raise RetriesLimitReached, message
+        end
 
         sleep(RETRIES_DELAYS_ARRAY[@retry_index])
         @retry_index += 1

--- a/lib/omni_parse_client_ruby/connection.rb
+++ b/lib/omni_parse_client_ruby/connection.rb
@@ -53,14 +53,7 @@ module OmniparseClient
         req[header] = val
       end
 
-      retry_on_server_error do
-        res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
-          http.request(req)
-        end
-        res.error! if !res.is_a?(Net::HTTPSuccess) && CLIENT_ERRORS.include?(res.code_type)
-
-        res
-      end
+      make_request(req)
     end
 
     def omni_post(request_url, params = {}, headers = {})
@@ -72,14 +65,7 @@ module OmniparseClient
         req[header] = val
       end
 
-      retry_on_server_error do
-        res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
-          http.request(req)
-        end
-        res.error! if !res.is_a?(Net::HTTPSuccess) && CLIENT_ERRORS.include?(res.code_type)
-
-        res
-      end
+      make_request(req)
     end
 
     # headers
@@ -127,6 +113,18 @@ module OmniparseClient
         sleep(RETRIES_DELAYS_ARRAY[@retry_index])
         @retry_index += 1
         retry
+      end
+    end
+
+    def make_request(request)
+      retry_on_server_error do
+        uri = request.uri
+        res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+          http.request(request)
+        end
+        res.error! if !res.is_a?(Net::HTTPSuccess) && CLIENT_ERRORS.include?(res.code_type)
+
+        res
       end
     end
 

--- a/lib/omni_parse_client_ruby/connection.rb
+++ b/lib/omni_parse_client_ruby/connection.rb
@@ -46,6 +46,7 @@ module OmniparseClient
 
     def omni_get(request_url, params = {}, headers = {})
       uri = URI(request_url)
+      uri.port = port
       uri.query = URI.encode_www_form(params)
       req = Net::HTTP::Get.new(uri)
       headers.each do |header, val|
@@ -53,7 +54,7 @@ module OmniparseClient
       end
 
       retry_on_server_error do
-        res = Net::HTTP.start(uri.hostname, uri.port) do |http|
+        res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
           http.request(req)
         end
         res.error! if !res.is_a?(Net::HTTPSuccess) && CLIENT_ERRORS.include?(res.code_type)
@@ -64,6 +65,7 @@ module OmniparseClient
 
     def omni_post(request_url, params = {}, headers = {})
       uri = URI(request_url)
+      uri.port = port
       req = Net::HTTP::Post.new(uri)
       req.set_form_data(params)
       headers.each do |header, val|
@@ -71,7 +73,7 @@ module OmniparseClient
       end
 
       retry_on_server_error do
-        res = Net::HTTP.start(uri.hostname, uri.port) do |http|
+        res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
           http.request(req)
         end
         res.error! if !res.is_a?(Net::HTTPSuccess) && CLIENT_ERRORS.include?(res.code_type)

--- a/lib/omni_parse_client_ruby/connection.rb
+++ b/lib/omni_parse_client_ruby/connection.rb
@@ -34,7 +34,8 @@ module OmniparseClient
       Net::HTTPInsufficientStorage,
       Net::HTTPLoopDetected,
       Net::HTTPRequestTimeout,
-      Net::HTTPBadRequest
+      Net::HTTPBadRequest,
+      Net::HTTPNotFound
     ].freeze
 
     # constructor

--- a/lib/omni_parse_client_ruby/parsers/html_parser.rb
+++ b/lib/omni_parse_client_ruby/parsers/html_parser.rb
@@ -46,7 +46,6 @@ module OmniparseClient
         response = omni_post(last_request,
                              params,
                              headers)
-
         self.last_response = Response.new(response)
         last_response
       end

--- a/lib/omni_parse_client_ruby/parsers/html_parser.rb
+++ b/lib/omni_parse_client_ruby/parsers/html_parser.rb
@@ -21,7 +21,7 @@ module OmniparseClient
       # @omni_html.all(parser_id)
       def all
         self.last_request = base_url + index_path
-        response = omni_get(last_request, headers)
+        response = omni_get(last_request, {}, headers)
         self.last_response = Response.new(response)
         last_response
       end

--- a/lib/omni_parse_client_ruby/parsers/omni_fixture.rb
+++ b/lib/omni_parse_client_ruby/parsers/omni_fixture.rb
@@ -20,9 +20,7 @@ module OmniparseClient
       # @omni_fixture.all(parser_id)
       def all(parser_id)
         self.last_request = base_url + index_path
-        # https://github.com/rest-client/rest-client#passing-advanced-options
-        headers_and_params = headers.merge(params: params(parser_id))
-        response = omni_get(last_request, headers_and_params)
+        response = omni_get(last_request, params(parser_id), headers)
         self.last_response = Response.new(response)
         last_response
       end

--- a/lib/omni_parse_client_ruby/parsers/vcf_parser.rb
+++ b/lib/omni_parse_client_ruby/parsers/vcf_parser.rb
@@ -21,7 +21,7 @@ module OmniparseClient
       # @omni_vcf.all(parser_id)
       def all
         self.last_request = base_url + index_path
-        response = omni_get(last_request, headers)
+        response = omni_get(last_request, {}, headers)
         self.last_response = Response.new(response)
         last_response
       end

--- a/lib/omni_parse_client_ruby/response.rb
+++ b/lib/omni_parse_client_ruby/response.rb
@@ -7,11 +7,11 @@ module OmniparseClient
 
     attr_reader :resp, :json, :code, :headers
 
-    def initialize(rest_client_response)
-      @resp     = rest_client_response
+    def initialize(client_response)
+      @resp     = client_response
       @json     = JSON.parse(@resp.body)
-      @code     = @resp.code
-      @headers  = @resp.headers
+      @code     = @resp.code.to_i
+      @headers  = @resp.to_hash
     end
   end
 end

--- a/omni_parse_client_ruby.gemspec
+++ b/omni_parse_client_ruby.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
                    'lib/omni_parse_client_ruby/parsers/html_parser.rb']
   s.homepage    = 'http://www.fmadata.com/'
   s.license     = 'MIT'
-  s.add_dependency 'rest-client', '~> 2.0.2', '>= 2.0.2'
-  s.add_development_dependency 'minitest-stub-const'
-  s.add_development_dependency 'webmock'
+  s.add_dependency 'net-http', '~> 0.3.2'
+  s.add_development_dependency 'minitest-stub-const', '~> 0.6'
+  s.add_development_dependency 'webmock', '~> 3.18'
 end

--- a/omni_parse_client_ruby.gemspec
+++ b/omni_parse_client_ruby.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'omni_parse_client_ruby'
-  s.version     = '1.2.0'
-  s.date        = '2019-10-17'
+  s.version     = '1.3.0'
+  s.date        = '2023-09-28'
   s.summary     = 'Client for omniparse API'
   s.description = 'Client for omniparse API'
   s.authors     = ['Brian Long', 'Michał Marzec', 'Paweł Jermalonek']

--- a/test/test_connection.rb
+++ b/test/test_connection.rb
@@ -74,6 +74,31 @@ class TestConnection < MiniTest::Test
     end
   end
 
+  define_method "test_omni_get_headers_and_params" do
+    stub_request(:get, @request_url + '?parser_id=555').with(
+      headers: { 'Set-Cookie' => 'test' }
+    ).to_return(status: 200)
+
+    stub_client_retry_delays do
+      @omni_client.omni_get(
+        @request_url, { 'parser_id' => 555 }, { 'Set-Cookie' => 'test' }
+      )
+    end
+  end
+
+  define_method "test_omni_post_headers_and_params" do
+    stub_request(:post, @request_url).with(
+      headers: { 'Set-Cookie' => 'test' },
+      body: { 'omni_parser_id' => 555 }
+    ).to_return(status: 200)
+
+    stub_client_retry_delays do
+      @omni_client.omni_post(
+        @request_url, { 'omni_parser_id' => 555 }, { 'Set-Cookie' => 'test' }
+      )
+    end
+  end
+
   private
 
   def stub_client_retry_delays(&block)

--- a/test/test_connection.rb
+++ b/test/test_connection.rb
@@ -7,18 +7,18 @@ class TestConnection < MiniTest::Test
     @omni_client = Omni::Client.new(host: 'www.example.com',
                                     version: 'api/v1',
                                     api_key: '123')
-    @request_url = 'www.example.com'
+    @request_url = 'http://www.example.com'
   end
 
   ERROR_CODES_MESSAGES =
     {
-      '500': '500 Internal Server Error',
-      '501': '501 Not Implemented',
-      '502': '502 Bad Gateway',
-      '503': '503 Service Unavailable',
-      '504': '504 Gateway Timeout',
-      '507': '507 Insufficient Storage',
-      '508': '508 Loop Detected'
+      '500': '500 Net::HTTPInternalServerError',
+      '501': '501 Net::HTTPNotImplemented',
+      '502': '502 Net::HTTPBadGateway',
+      '503': '503 Net::HTTPServiceUnavailable',
+      '504': '504 Net::HTTPGatewayTimeout',
+      '507': '507 Net::HTTPInsufficientStorage',
+      '508': '508 Net::HTTPLoopDetected'
     }.freeze
 
   ERROR_CODES_MESSAGES.each do |error_code, error_message|
@@ -26,7 +26,7 @@ class TestConnection < MiniTest::Test
       define_method "test_omni_#{method}_server_error_#{error_code}" do
         code = error_code.to_s.to_i
         stub_request(method, @request_url).to_return(body: 'abc', status: code)
-        stub_rest_client do
+        stub_client_retry_delays do
           err =
             assert_raises OmniparseClient::Connection::RetriesLimitReached do
               @omni_client.send("omni_#{method}", @request_url)
@@ -41,7 +41,7 @@ class TestConnection < MiniTest::Test
   %i[get post].each do |method|
     define_method "test_omni_#{method}_socketerror" do
       stub_request(method, @request_url).to_raise(SocketError)
-      stub_rest_client do
+      stub_client_retry_delays do
         err = assert_raises OmniparseClient::Connection::RetriesLimitReached do
           @omni_client.send("omni_#{method}", @request_url)
         end
@@ -53,11 +53,11 @@ class TestConnection < MiniTest::Test
   %i[get post].each do |method|
     define_method "test_omni_#{method}_timeout" do
       stub_request(method, @request_url).to_timeout
-      stub_rest_client do
+      stub_client_retry_delays do
         err = assert_raises OmniparseClient::Connection::RetriesLimitReached do
           @omni_client.send("omni_#{method}", @request_url)
         end
-        assert_equal 'Timed out connecting to server', err.message
+        assert_equal 'execution expired', err.message
       end
     end
   end
@@ -65,7 +65,7 @@ class TestConnection < MiniTest::Test
   %i[get post].each do |method|
     define_method "test_omni_#{method}_standarderror" do
       stub_request(method, @request_url).to_raise(StandardError)
-      stub_rest_client do
+      stub_client_retry_delays do
         err = assert_raises StandardError do
           @omni_client.send("omni_#{method}", @request_url)
         end
@@ -76,7 +76,7 @@ class TestConnection < MiniTest::Test
 
   private
 
-  def stub_rest_client(&block)
+  def stub_client_retry_delays(&block)
     OmniparseClient::Connection.stub_const(
       :RETRIES_DELAYS_ARRAY, [0, 0, 0, 0, 0]
     ) do

--- a/test/test_connection.rb
+++ b/test/test_connection.rb
@@ -74,7 +74,7 @@ class TestConnection < MiniTest::Test
     end
   end
 
-  define_method "test_omni_get_headers_and_params" do
+  def test_omni_get_headers_and_params
     stub_request(:get, @request_url + '?parser_id=555').with(
       headers: { 'Set-Cookie' => 'test' }
     ).to_return(status: 200)
@@ -86,7 +86,7 @@ class TestConnection < MiniTest::Test
     end
   end
 
-  define_method "test_omni_post_headers_and_params" do
+  def test_omni_post_headers_and_params
     stub_request(:post, @request_url).with(
       headers: { 'Set-Cookie' => 'test' },
       body: { 'omni_parser_id' => 555 }

--- a/test/test_connection.rb
+++ b/test/test_connection.rb
@@ -7,7 +7,7 @@ class TestConnection < MiniTest::Test
     @omni_client = Omni::Client.new(host: 'www.example.com',
                                     version: 'api/v1',
                                     api_key: '123')
-    @request_url = 'http://www.example.com'
+    @request_url = 'https://www.example.com'
   end
 
   ERROR_CODES_MESSAGES =

--- a/test/test_html_parser.rb
+++ b/test/test_html_parser.rb
@@ -8,7 +8,10 @@ class HtmlParserTest < Minitest::Test
                                    version: 'api/v1',
                                    api_key: '123')
     @html_parser = omni_client.html
-    @html_parser_params = { omni_parser_id: 1, html: '<body></body>' }
+    @html_parser_params = {
+      omni_parser_id: 1,
+      html: '<html><body><div class="price">$1,234</div></body></html>'
+    }
   end
 
   def test_has_headers
@@ -18,5 +21,26 @@ class HtmlParserTest < Minitest::Test
   def test_has_params
     assert @html_parser.prepare(@html_parser_params)
     assert @html_parser.params.is_a?(Hash)
+  end
+
+  def test_parse
+    url = 'https://www.example.com/api/v1/html_parser/parse'
+    stub_request(:post, url).with(
+      body: @html_parser_params
+    ).to_return(
+      status: 200,
+      body: "{\"omni_parser_id\":1,\"omni_configs_ids\":[1],\"parser_type\":\"html\",\"values\":{\"asking_price\":[\"\$1,234\"]}}"
+    )
+
+    @html_parser.parse(@html_parser_params)
+  end
+
+  def test_blank_html
+    url = 'https://www.example.com/api/v1/html_parser/parse'
+    stub_request(:post, url).with(
+      body: { omni_parser_id: 1, html: '' }
+    ).to_return(status: 400, body: "{\"errors\":[\"Html not present\"]}")
+
+    @html_parser.parse({ omni_parser_id: 1, html: '' })
   end
 end

--- a/test/test_html_parser.rb
+++ b/test/test_html_parser.rb
@@ -39,8 +39,10 @@ class HtmlParserTest < Minitest::Test
     url = 'https://www.example.com/api/v1/html_parser/parse'
     stub_request(:post, url).with(
       body: { omni_parser_id: 1, html: '' }
-    ).to_return(status: 400, body: "{\"errors\":[\"Html not present\"]}")
+    ).to_raise(Net::HTTPClientException.new('400 Bad Request', ''))
 
-    @html_parser.parse({ omni_parser_id: 1, html: '' })
+    assert_raises Net::HTTPClientException do
+      @html_parser.parse({ omni_parser_id: 1, html: '' })
+    end
   end
 end


### PR DESCRIPTION
PR removes rest-client gem and uses net-http instead.

Testing steps:
- gem install all required gems (listed in gemspec)
- run `rake test`

https://www.pivotaltracker.com/story/show/182465391