### PR TITLE
188763178 - Add OMNIPARSE_HOST env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /tmp/
 
 # Used by dotenv library to load environment variables.
-# .env
+.env
 
 ## Specific to RubyMotion:
 .dat*

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /tmp/
 
 # Used by dotenv library to load environment variables.
-.env
+# .env
 
 ## Specific to RubyMotion:
 .dat*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-OMNIPARSE_HOST*.gem
+*.gem
 *.rbc
 /.config
 /coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-*.gem
+OMNIPARSE_HOST*.gem
 *.rbc
 /.config
 /coverage/
@@ -9,9 +9,6 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
-
-# Used by dotenv library to load environment variables.
-# .env
 
 ## Specific to RubyMotion:
 .dat*

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ RETRIES_DELAYS_ARRAY=[5, 30, 2*60, 10*60, 30*60]
 - **OMNI_MAX_RETRIES_COUNT** should be an integer.
 - **OMNI_RETRIES_DELAYS_ARRAY** should be a string of integers, separeted by `,`. Each integer relates to consequent delay time in seconds. Array length should not be lower than `MAX_RETRIES_COUNT`.
 
-Example for .env file:
+Example of environmental variables that gem is utilizing:
 ```ruby
 OMNI_MAX_RETRIES_COUNT=5
 OMNI_RETRIES_DELAYS_ARRAY=1,5,10,15,25

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Example for .env file:
 ```ruby
 OMNI_MAX_RETRIES_COUNT=5
 OMNI_RETRIES_DELAYS_ARRAY=1,5,10,15,25
+OMNIPARSE_HOST=www.omniparse.com
 ```
 
 ## HTML parsing

--- a/lib/omni_parse_client_ruby/connection.rb
+++ b/lib/omni_parse_client_ruby/connection.rb
@@ -9,6 +9,7 @@ module OmniparseClient
 
     attr_reader :api_key, :port, :version, :host
 
+    DEFAULT_URL           = ENV['OMNIPARSE_HOST'] || 'www.omniparse.com'
     DEFAULT_PORT          = 443
     DEFAULT_VERSION       = '/api/v1'
     # Retries count if network error occurs
@@ -39,7 +40,7 @@ module OmniparseClient
 
     # constructor
     def setup_connection(p = {})
-      @host       = p[:host] || OMNIPARSE_HOST
+      @host       = p[:host] || DEFAULT_URL
       @port       = p[:port] || DEFAULT_PORT
       @version    = p[:version] || DEFAULT_VERSION
       @api_key    = p[:api_key]

--- a/lib/omni_parse_client_ruby/connection.rb
+++ b/lib/omni_parse_client_ruby/connection.rb
@@ -9,7 +9,6 @@ module OmniparseClient
 
     attr_reader :api_key, :port, :version, :host
 
-    DEFAULT_URL           = 'www.omniparse.com'
     DEFAULT_PORT          = 443
     DEFAULT_VERSION       = '/api/v1'
     # Retries count if network error occurs
@@ -40,7 +39,7 @@ module OmniparseClient
 
     # constructor
     def setup_connection(p = {})
-      @host       = p[:host] || DEFAULT_URL
+      @host       = p[:host] || OMNIPARSE_HOST
       @port       = p[:port] || DEFAULT_PORT
       @version    = p[:version] || DEFAULT_VERSION
       @api_key    = p[:api_key]


### PR DESCRIPTION
Testing notes:
- In red2 development set up the omni_parse_client_ruby path in gemfile. Use the location of this branch.
- Run rails console and try the following:
- - @omni = Omni::Client.new(host: nil, version: '/api/v1', api_key: 'key', port: 3000)
- This should return Omni Client Class with host attribute( "www.omniparse.com")
- - Set temporary Environment Variable (export OMNIPARSE_HOST=www.omniparse2.com)
- This should return Omni Client Class with host attribute( "www.omniparse2.com")